### PR TITLE
Change options for `existing_value_conflict`

### DIFF
--- a/projectcard/examples/roadway-property-change.yml
+++ b/projectcard/examples/roadway-property-change.yml
@@ -14,7 +14,11 @@ roadway_property_change:
       osm_node_id: '4322'
   property_changes:
     lanes:
-      set: 2
+      existing: 3
+      change: -1
+      existing_value_conflict: error
     bicycle_facility:
+      existing: 1
       set: 3
+      existing_value_conflict: skip
 notes: Simple road diet

--- a/projectcard/schema/changes/defs/property_set.json
+++ b/projectcard/schema/changes/defs/property_set.json
@@ -14,6 +14,12 @@
     "properties" : {
         "existing" : {"type": ["number", "string"]},
         "change" : {"type" : ["number","string"]},
-        "set" : {"type": ["number", "string"]}
+        "set" : {"type": ["number", "string"]},
+        "existing_value_conflict": {
+          "type":"string",
+          "enum":["error","warn","skip"],
+          "default":"warn",
+          "description":"Only used if 'existing' provided in project card and `existing` doesn't match the existing network value. `error` will raise an error, `warn` will warn the user, and `skip` will skip the change for that property (note it will still apply any remaining property changes). Defaults to `warn`."
+        }
     }
 }

--- a/projectcard/schema/changes/defs/scoped_property_set.json
+++ b/projectcard/schema/changes/defs/scoped_property_set.json
@@ -4,11 +4,17 @@
     "$defs": {
         "set_num": {"type": "number", "minimum": 0},
         "change_num": {"type": "number"},
+        "existing_value_conflict": {
+          "type":"string",
+          "enum":["error","warn","skip"],
+          "default":"warn",
+          "description":"Only used if 'existing' provided in project card and `existing` doesn't match the existing network value. `error` will raise an error, `warn` will warn the user, and `skip` will skip the change for that property (note it will still apply any remaining property changes). Defaults to `warn`."
+        },
         "overwrite_scoped": {
           "type":"string",
-          "enum":["all","conflicting","false"],
-          "default":"false",
-          "description":"If 'all', all scoped items will be overwritten. If 'conflicting', only conflicting scoped items will be overwritten. If 'none', no scoped items will be overwritten and error will be raised if there are conflicts."
+          "enum":["all","conflicting","error"],
+          "default":"error",
+          "description":"If 'all', all scoped items will be overwritten. If 'conflicting', only conflicting scoped items will be overwritten. If 'error', no scoped items will be overwritten and error will be raised if there are conflicts."
         },
         "scoped_property_set_item":{
             "type": "object",
@@ -34,7 +40,8 @@
               "change": {"$ref": "#/$defs/change_num"},
               "category": {"type":"array"},
               "timespan": {"$ref": "../../defs/timespan.json"},
-              "overwrite_conflicting": {"type":"boolean", "default":false, "description":"If true, this item will overwrite any conflicting scoped items. If false, this item will be error if there is a conflicting item."}
+              "overwrite_scoped": {"$ref": "#/$defs/overwrite_scoped"},
+              "existing_value_conflict": {"$ref": "#/$defs/existing_value_conflict_error"}
               }
           }
     },
@@ -53,6 +60,7 @@
         "set" : {"$ref": "#/$defs/set_num"},
         "change" : {"$ref": "#/$defs/change_num"},
         "scoped" : {"type":"array","items": {"$ref": "#/$defs/scoped_property_set_item"}},
-        "overwrite_scoped": {"$ref": "#/$defs/overwrite_scoped"}
+        "overwrite_scoped": {"$ref": "#/$defs/overwrite_scoped"},
+        "existing_value_conflict": {"$ref": "#/$defs/existing_value_conflict"}
     }
 }


### PR DESCRIPTION
When combining the power of the new WranglerConfig with the options originally created here, I think we would be better served by having three options:

- `error`, `warn`, and `skip` (new option, to skip implementation)